### PR TITLE
Update popup-resources.js

### DIFF
--- a/popup/popup-resources.js
+++ b/popup/popup-resources.js
@@ -27,7 +27,7 @@ function insertTableRow(host, securityInfo) {
     addCell(row, document.createTextNode(securityInfo.isExtendedValidation ? 'Yes' : 'No'), securityInfo.cipherSuite);
 
     i18n_test = browser.i18n.getMessage("popupRunTest");
-    addCell(row, createLink(i18n_test, 'https://www.ssllabs.com/ssltest/analyze.html?d=' + host), '');
+    addCell(row, createLink(i18n_test, 'https://www.ssllabs.com/ssltest/analyze.html?hideResults=on&d=' + host), '');
 }
 
 function clearTable() {


### PR DESCRIPTION
Hello,

the param "hideResults=on" is necessary for not showing your checked domainname after the test in the result list on ssllabs.com -> otherwise your checked domainname is visible in the list as default like now

Best regards, Chris